### PR TITLE
fix(openapi.yml): Ensure that attributes of type: 3 are str or int

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -659,8 +659,12 @@ components:
                 - 3
             name:
               type: string
+            # Nominally a string, but some devices (e.g. Zigbee sensors
+            # reporting core:ManufacturerId) send a bare number under type 3.
             value:
-              type: string
+              oneOf:
+                - type: string
+                - type: number
           required:
             - name
             - type


### PR DESCRIPTION
**Context**: For some devices, the manufacturer can be an int instead of a string, this make the API descriptor fail. It likely happens when manufacturer is unknown for the Tahoma box

**Solution**: Allow such property to be either str or int, so API will work

Will fix https://github.com/Somfy-Developer/Somfy-TaHoma-Developer-Mode/issues/234